### PR TITLE
Added Go built tag note to AWS module

### DIFF
--- a/pages/docs/modules/aws.mdx
+++ b/pages/docs/modules/aws.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # aws
 
-<Callout type="warning" emoji="⚠️">
+<Callout type="info" emoji="ℹ️">
   This module requires that Risor has been compiled with the `aws` Go build tag.
   When compiling **manually**, [make sure you specify `-tags aws`](https://github.com/risor-io/risor#build-and-install-the-cli-from-source).
 </Callout>

--- a/pages/docs/modules/aws.mdx
+++ b/pages/docs/modules/aws.mdx
@@ -1,4 +1,11 @@
+import { Callout } from 'nextra/components';
+
 # aws
+
+<Callout type="warning" emoji="⚠️">
+  This module requires that Risor has been compiled with the `aws` Go build tag.
+  When compiling **manually**, [make sure you specify `-tags aws`](https://github.com/risor-io/risor#build-and-install-the-cli-from-source).
+</Callout>
 
 The `aws` module exposes a simple interface that wraps the AWS SDK v2 for Go.
 Create a client by providing the name of the service you want to use. All API


### PR DESCRIPTION
Adds a warning note that the module requires special compilation flag:

![image](https://github.com/risor-io/risor-site/assets/2477952/049eac54-8052-495b-9358-0db3d7a038c4)
