### PR TITLE
Add example for iterating maps

### DIFF
--- a/pages/docs/syntax.mdx
+++ b/pages/docs/syntax.mdx
@@ -155,6 +155,15 @@ for i, value := range array {
 }
 ```
 
+Iterating maps is supported as well.
+
+```risor copy
+m := {"hello": 42, "world": true}
+for key, val := range m {
+    print(key, val)
+}
+```
+
 ```risor copy
 for {
     print("infinite loop")


### PR DESCRIPTION
In response to this issue: https://github.com/risor-io/risor/issues/310

I was using a Python-style syntax for iterating maps, and was surprised that `map.items()` returns the object's index as the first argument of the iterator, and not the key.